### PR TITLE
docs: set transfer type as string

### DIFF
--- a/docs/schemas/DataFlowBaseMessage.schema.json
+++ b/docs/schemas/DataFlowBaseMessage.schema.json
@@ -37,23 +37,8 @@
             "description": "Callback URL as a string"
         },
         "transferType": {
-            "type": "object",
-            "properties": {
-                "destinationType": {
-                    "type": "string"
-                },
-                "flowType": {
-                    "type": "string",
-                    "enum": [
-                        "pull",
-                        "push"
-                    ]
-                }
-            },
-            "required": [
-                "destinationType",
-                "flowType"
-            ]
+            "type": "string",
+            "description": "the flow transfer type"
         },
         "metadata": {
             "type": "object"

--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -22,14 +22,14 @@ The following terms are used to describe concepts in this specification.
 ## Base Concepts
 
 The DSP Specification models consumer access to a provider dataset in the [=Control Plane=] as a [=Transfer
-Process=](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC4/#dfn-transfer-process). The
+Process=](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/#dfn-transfer-process). The
 [=Wire Protocol=] operations in the [=Data Plane=] that facilitate data exchange are modeled as a [=Data Flow=]. A
 [=Data Flow=] represents the current state of the physical data transfer.
 
 ### Data Transfer Types
 
 A [=Data Flow=] is one of two data transfer types as defined in the [DSP
-Specification](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC4/#data-transfer-types):
+Specification](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/#data-transfer-types):
 
 | Push            | Pull              |
 | --------------- | ----------------- |
@@ -44,7 +44,7 @@ via a consumer subscriber, or a provider HTTP REST API invoked by a consumer cli
 #### Finite vs Non-Finite Data
 
 DSP further distinguishes [Finite and Non-Finite
-Data](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC4/#finite-and-non-finite-data).
+Data](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/#finite-and-non-finite-data).
 Finite data has a demarcated end, for example, a file or set of files. Non-Finite data has no specified end. It could be
 an ongoing event stream or an HTTP REST API.
 
@@ -277,10 +277,7 @@ The following is a non-normative example of a `DataFlowPrepareMessage`:
   "agreementId": "test-agreement-id",
   "datasetId": "asset-id",
   "callbackAddress": "https://example.com/provider/callback",
-  "transferType": {
-    "destinationType": "com.test.s3",
-    "flowtype": "PUSH"
-  },
+  "transferType": "com.test.s3-PUSH",
   "labels": ["gold", "blue"],
   "metadata": {
     "bucketName": "destinationBucket",
@@ -362,10 +359,7 @@ provider and must be accessed by the provider data plane using an API Key:
   "agreementId": "test-agreement-id",
   "datasetId": "asset-id",
   "callbackAddress": "https://example.com/provider/callback",
-  "transferType": {
-    "destinationType": "com.test.http",
-    "flowtype": "PULL"
-  },
+  "transferType": "com.test.http-PULL",
   "dataAddress": {
     "type": "https://w3id.org/idsa/v4.1/HTTP",
     "endpoint": "http://dataplane.provider.com/api/public",
@@ -613,7 +607,7 @@ The following is a non-normative example of a Data Plane registration data objec
   "name": "My Data Plane",
   "description": "My Data Plane Description",
   "endpoint": "https://example.com/signaling",
-  "transferTypes": ["com.test.http-pull"],
+  "transferTypes": ["com.test.http-PULL"],
   "authorization": [
     {
       "type": "..."
@@ -624,19 +618,6 @@ The following is a non-normative example of a Data Plane registration data objec
 ```
 
 ##### Transfer Types
-
-A non-normative transfer type scheme can be defined as follows:
-
-`[FORWARDTYPE]-[push|pull](-[RESPONSETYPE])`
-
-where:
-
-- `FORWARDTYPE` is the name of the data transfer type. the name should include a qualifier and protocol identifier in
-  the form of `[qualifier].[protocol]`, for example, `com.test.http`. The forward type is case-insensitive and must be
-  unique.
-- `PUSH` or `PULL` indicates whether the data transfer type is push or pull. The type is case-insensitive.
-- `RESPONSETYPE` is optional and indicates whether the data transfer type supports response messages. It is the same
-  format as the `FORWARDTYPE`.
 
 Please note that the standardization of the transfer types is not in the scope of this specification. Every dataspace
 can define and document their own transfer types.

--- a/signaling-openapi.yaml
+++ b/signaling-openapi.yaml
@@ -652,12 +652,20 @@ components:
           example: https://example.com/controlplanes/xyz/callback
           format: uri
         transferType:
+<<<<<<< HEAD
           $ref: '#/components/schemas/TransferType'
         labels:
           type: array
         metadata:
           type: object
           description: free-form object type used by the control plane to pass flow related info to the data plane
+=======
+          type: string
+          description: The flow transfer type
+          example: com.test.http-PULL
+        dataAddress:
+          $ref: '#/components/schemas/DataAddress'
+>>>>>>> 3d139fe (docs: set transfer type as string)
 
     DataFlowPrepareMessage:
       allOf:
@@ -786,22 +794,6 @@ components:
           type: string
           description: The value of the property
           example: 5up3r53cur3t0k3n
-
-    TransferType:
-      type: object
-      required:
-        - destinationType
-        - flowType
-      properties:
-        destinationType:
-          type: string
-          description: The type of destination for the data transfer
-          example: com.test.http
-        flowType:
-          type: string
-          description: The type of data flow
-          enum: [ pull, push ]
-          example: pull
 
     DataPlaneRegistrationData:
       type: object


### PR DESCRIPTION
Convert transferType as a string with an example format that's not standardized in this spec

Closes #19 