### PR TITLE
docs: remove response body on the /started endpoint

### DIFF
--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -381,17 +381,16 @@ provider and must be accessed by the provider data plane using an API Key:
 The `started` request signals to the consumer [=Data Plane=] that a data transmission has begun and that a [state
 transition](#data-flow-state-machine) should be triggered. For pull transfers, this indicates the consumer [=Data
 Plane=] may fetch data. For push transfers, this indicates the provider has already started sending data. The request
-results in a state machine transition to STARTED and the [=Data Plane=] MUST return HTTP 200 OK and a
-`DataFlowResponseMessage`.
+results in a state machine transition to STARTED and the [=Data Plane=] MUST return HTTP 200 OK.
 
 This signal occurs exclusively on the consumer side.
 
-|                 |                                                                                                                                                                                |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **HTTP Method** | `POST`                                                                                                                                                                         |
-| **URL Path**    | `/dataflows/:id/started`                                                                                                                                                       |
-| **Request**     | [`DataFlowStartedNotificationMessage`](#dataflowstartednotificationmessage)                                                                                                    |
-| **Response**    | `HTTP 200` with a [`DataFlowResponseMessage`](#dataflowresponsemessage) OR `HTTP 202` with a [`DataFlowResponseMessage`](#dataflowresponsemessage) OR `HTTP 4xx Client Error`. |
+|                 |                                                                             |
+|-----------------|-----------------------------------------------------------------------------|
+| **HTTP Method** | `POST`                                                                      |
+| **URL Path**    | `/dataflows/:id/started`                                                    |
+| **Request**     | [`DataFlowStartedNotificationMessage`](#dataflowstartednotificationmessage) |
+| **Response**    | `HTTP 200` OR `HTTP 4xx Client Error`.                                      |
 
 ##### DataFlowStartedNotificationMessage
 

--- a/signaling-openapi.yaml
+++ b/signaling-openapi.yaml
@@ -97,43 +97,7 @@ paths:
             example: flow-1234
       responses:
         '200':
-          description: DataFlow started successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataFlowResponseMessage'
-              example:
-                example:
-                  dataplaneId: dataplane-64345
-                  state: STARTED
-                  dataAddress:
-                    '@type': DataAddress
-                    endpointType: https://23id.org.idsa/v4.1/HTTP
-                    endpoint: https://example.com/api/data
-                    endpointProperties:
-                      - '@type': EndpointProperty
-                        name: authorization
-                        value: 5up3r53cur3t0k3n
-                      - '@type': EndpointProperty
-                        name: authType
-                        value: bearer
-        '202':
-          description: Start request received, DataFlow is being started
-          headers:
-            Location:
-              description: The URL to retrieve the data flow status
-              schema:
-                type: string
-                format: uri
-              example: /dataflows/flow-1234/status
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataFlowResponseMessage'
-              example:
-                example:
-                  dataplaneId: dataplane-64345
-                  state: STARTING
+          description: Signals to a data plane that the data transmission has been started normally.
         '400':
           description: Bad Request - invalid input, invalid object state or missing required parameters, omitting the
             dataAddress on consumer-pull transfers or supplying a dataAddress on provider-push transfers.


### PR DESCRIPTION
### What
removed response body on the `/started` signal that's called on the consumer data-plane when the transfer has been actually started.

### Why
It's not needed, the data-plane needs to change the state and, eventually, to actually start fetching data (in case of pull transfer) and just tell the control-plane that the signal has been received, but nothing needs to be returned back to control-plane

Closes #15 