### PR TITLE
refactor: cleanup dataplane registration

### DIFF
--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -636,9 +636,9 @@ configuration is applied is implementation-specific.
 A [=Control Plane=] implementation MAY support registration through an endpoint. The endpoint is defined as follows:
 
 |                 |                                       |
-| --------------- | ------------------------------------- |
+|-----------------|---------------------------------------|
 | **HTTP Method** | `POST`                                |
-| **URL Path**    | `/dataplanes/registration`            |
+| **URL Path**    | `/dataplanes/register`                |
 | **Request**     | [`DataPlaneRegistrationMessage`]      |
 | **Response**    | `HTTP 200` OR `HTTP 4xx Client Error` |
 
@@ -655,12 +655,12 @@ TODO: Define DataPlaneRegistrationRegistrationMessage, including the `dataplaneI
 If the [=Control Plane=] implementation supports endpoint registration, it MUST support endpoint updates. The endpoint
 update is defined as follows:
 
-|                 |                                         |
-| --------------- | --------------------------------------- |
-| **HTTP Method** | `PUT`                                   |
-| **URL Path**    | `/dataplanes/:dataplaneId/registration` |
-| **Request**     | [`DataPlaneRegistrationMessage`]        |
-| **Response**    | `HTTP 200` OR `HTTP 4xx Client Error`   |
+|                 |                                       |
+|-----------------|---------------------------------------|
+| **HTTP Method** | `PUT`                                 |
+| **URL Path**    | `/dataplanes/:dataplaneId`            |
+| **Request**     | [`DataPlaneRegistrationMessage`]      |
+| **Response**    | `HTTP 200` OR `HTTP 4xx Client Error` |
 
 Update semantics are defined as a `replace` operation.
 
@@ -669,11 +669,11 @@ Update semantics are defined as a `replace` operation.
 If the [=Control Plane=] implementation supports endpoint registration, it MUST support endpoint deletion defined as
 follows:
 
-|                 |                                         |
-| --------------- | --------------------------------------- |
-| **HTTP Method** | `DELETE`                                |
-| **URL Path**    | `/dataplanes/:dataplaneId/registration` |
-| **Response**    | `HTTP 204` OR `HTTP 4xx Client Error`   |
+|                 |                                       |
+|-----------------|---------------------------------------|
+| **HTTP Method** | `DELETE`                              |
+| **URL Path**    | `/dataplanes/:dataplaneId`            |
+| **Response**    | `HTTP 204` OR `HTTP 4xx Client Error` |
 
 ### Control Plane Registration
 

--- a/signaling-openapi.yaml
+++ b/signaling-openapi.yaml
@@ -431,9 +431,9 @@ paths:
     post:
       tags:
         - Data Plane Registration
-      summary: Register a data plane with a control plane.
+      summary: Register a data plane on the control plane.
       description: |
-        The register endpoint is hosted on the control plane, and may be used to register a data plane with the control plane.
+        The register endpoint is hosted on the control plane, and may be used to register a data plane on the control plane.
       operationId: registerDataplane
       requestBody:
         description: Data plane registration data
@@ -441,14 +441,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DataPlaneRegistrationData'
+              $ref: '#/components/schemas/DataPlaneRegistrationMessage'
       responses:
         '200':
           description: Data plane registered successfully
         '400':
           description: Bad Request - invalid input, invalid object state or missing required parameters
 
-  /dataplanes/{dataplaneId}/registration:
+  /dataplanes/{dataplaneId}:
     put:
         tags:
             - Data Plane Registration
@@ -470,7 +470,7 @@ paths:
             content:
               application/json:
                   schema:
-                    $ref: '#/components/schemas/DataPlaneRegistrationData'
+                    $ref: '#/components/schemas/DataPlaneRegistrationMessage'
         responses:
             '200':
               description: Data plane registration updated successfully
@@ -759,7 +759,7 @@ components:
           description: The value of the property
           example: 5up3r53cur3t0k3n
 
-    DataPlaneRegistrationData:
+    DataPlaneRegistrationMessage:
       type: object
       required: [dataplaneId, name, endpoint, transferTypes, authorization]
       properties:


### PR DESCRIPTION
### What

Adapt dataplane registration semantics to a more consistent format with the rest of the spec:
- `POST /dataplanes/register`: register a new dataplane
- `PUT /dataplanes/{id}`: update an existing dataplane
- `DELETE /dataplanes/{id}`: delete existing dataplane

