### PR TITLE
refactor: use DataFlowResponseMessage as body for /errored notification

### DIFF
--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -560,10 +560,10 @@ NOTE see [Terminated Event propagation](https://github.com/Metaform/dataplane-si
 request does not exist.
 
 |                 |                                           |
-| --------------- | ----------------------------------------- |
+|-----------------|-------------------------------------------|
 | **HTTP Method** | `POST`                                    |
 | **URL Path**    | `/transfers/:transferId/dataflow/errored` |
-| **Request**     | [`DataFlowErroredMessage`]                |
+| **Request**     | [`DataFlowResponseMessage`]               |
 | **Response**    | `HTTP 200` OR `HTTP 4xx Client Error`     |
 
 ## Registration


### PR DESCRIPTION
Use `DataFlowResponseMessage` as request body for the `/errored` notification.

This will permit to specify an `error` message, and it will be aligned with the `/prepared` and `/started` calls

Closes #28 