### PR TITLE
build: publish json schemas to github pages

### DIFF
--- a/.github/workflows/publish-json-schemas.yaml
+++ b/.github/workflows/publish-json-schemas.yaml
@@ -1,0 +1,27 @@
+---
+name: Publish json schema files
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/schemas/**'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: copy contexts into public folder
+        run: |
+          cp -r docs/schemas public/schemas/
+      - name: deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          keep_files: true


### PR DESCRIPTION
### What
Publish json schemas to github pages

### Why
So they can be referenced in the OpenAPI spec file

Closes #38 