### PR TITLE
docs: remove name and description attributes

### DIFF
--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -602,8 +602,6 @@ The following is a non-normative example of a Data Plane registration data objec
 ```json
 {
   "dataplaneId": "7d6fda82-98b6-4738-a874-1f2c003a79ff",
-  "name": "My Data Plane",
-  "description": "My Data Plane Description",
   "endpoint": "https://example.com/signaling",
   "transferTypes": ["com.test.http-PULL"],
   "authorization": [
@@ -693,8 +691,6 @@ The following is a non-normative example of a Control Plane registration data ob
 ```json
 {
   "dataplaneId": "bcf2d204-03bc-4354-8e92-b15b68d3c358",
-  "name": "My Control Plane",
-  "description": "My Control Plane Description",
   "endpoint": "https://example.com/signaling",
   "authorization": [
     {

--- a/signaling-control-plane-openapi.yaml
+++ b/signaling-control-plane-openapi.yaml
@@ -245,14 +245,6 @@ components:
           type: string
           description: The unique identifier of the data plane
           example: dataplane-64345
-        name:
-          type: string
-          description: A human-readable name for the data plane
-          example: My Data Plane
-        description:
-          type: string
-          description: A human-readable description of the data plane
-          example: This data plane is responsible for handling data transfers for project X.
         endpoint:
           type: string
           description: The base URL of the data plane's Signaling API endpoint

--- a/signaling-data-plane-openapi.yaml
+++ b/signaling-data-plane-openapi.yaml
@@ -372,14 +372,6 @@ components:
           type: string
           description: The unique identifier of the control plane
           example: controlplane-64345
-        name:
-          type: string
-          description: A human-readable name for the control plane
-          example: My Control Plane
-        description:
-          type: string
-          description: A human-readable description of the control plane
-          example: This control plane is the main DSP hub for company X..
         endpoint:
           type: string
           description: The base URL of the control plane's Signaling API endpoint


### PR DESCRIPTION
Remove name and description from control-plane and data-plane registration messages