### PR TITLE
refactor: convert registration messages to json schema

### DIFF
--- a/docs/schemas/AuthorizationEntry.schema.json
+++ b/docs/schemas/AuthorizationEntry.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "AuthorizationEntry",
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "The authorization profile",
+      "examples": ["oauth2_client_credentials"]
+    },
+    "tokenEndpoint": {
+      "type": "string",
+      "description": "The token endpoint to be used for obtaining access tokens",
+      "examples": ["https://auth.example.com/oauth2/token"]
+    },
+    "clientId": {
+      "type": "string",
+      "description": "The client ID for the authorization profile",
+      "examples": ["123456789"]
+    },
+    "clientSecret": {
+      "type": "string",
+      "description": "The client secret for the authorization profile",
+      "examples": ["s3cr3t"]
+    }
+  }
+}

--- a/docs/schemas/ControlPlaneRegistrationMessage.schema.json
+++ b/docs/schemas/ControlPlaneRegistrationMessage.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "ControlPlaneRegistrationMessage",
+  "required": ["controlplaneId", "endpoint", "authorization"],
+  "properties": {
+    "controlplaneId": {
+      "type": "string",
+      "description": "The unique identifier of the control plane",
+      "examples": ["controlplane-64345"]
+    },
+    "endpoint": {
+      "type": "string",
+      "description": "The base URL of the control plane's Signaling API endpoint",
+      "format": "uri",
+      "examples": ["https://dataplane.example.com/api/v1/signaling"]
+    },
+    "authorization": {
+      "type": "array",
+      "description": "an array of one or more authorization objects",
+      "items": {
+        "$ref": "https://eclipse-dataplane-signaling.github.io/dataplane-signaling/schemas/AuthorizationEntry.schema.json"
+      }
+    }
+  }
+}

--- a/docs/schemas/DataPlaneRegistrationMessage.schema.json
+++ b/docs/schemas/DataPlaneRegistrationMessage.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "DataPlaneRegistrationMessage",
+  "required": ["dataplaneId", "endpoint", "transferTypes", "authorization"],
+  "properties": {
+    "dataplaneId": {
+      "type": "string",
+      "description": "The unique identifier of the data plane",
+      "examples": ["dataplane-64345"]
+    },
+    "endpoint": {
+      "type": "string",
+      "description": "The base URL of the data plane's Signaling API endpoint",
+      "format": "uri",
+      "examples": ["https://dataplane.example.com/api/v1/signaling"]
+    },
+    "transferTypes": {
+      "type": "array",
+      "description": "A list of transfer types supported by the data plane",
+      "items": {
+        "type": "string",
+        "description": "The flow transfer type",
+        "examples": ["com.test.http-pull"]
+      },
+      "examples": [
+        ["com.test.http-pull", "com.test.mqtt-push-com.test.mqtt"]
+      ]
+    },
+    "authorization": {
+      "type": "array",
+      "description": "an array of one or more authorization objects",
+      "items": {
+        "$ref": "https://eclipse-dataplane-signaling.github.io/dataplane-signaling/schemas/AuthorizationEntry.schema.json"
+      }
+    },
+    "labels": {
+      "type": "array",
+      "description": "an array of one of more strings corresponding to labels associated with the data plane",
+      "items": {
+        "type": "string"
+      },
+      "examples": [
+        ["label1", "label2"]
+      ]
+    }
+  }
+}

--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -585,14 +585,15 @@ example, a registration may be per deployment or per participant in a multi-part
 
 Data Plane registration is the process where a [=Data Plane=] is registered with the [=Control Plane=].
 
-#### The Data Plane Registration Type
+#### The Data Plane Registration Message
 
-The data plane registration object contains the following properties:
+The data plane registration message object contains the following properties:
 
 |              |                                                                                                     |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| **Schema**   | [JSON Schema]()                                                                                     |
-| **Required** | - `endpoint`: The data plane signaling endpoint.                                                    |
+|--------------|-----------------------------------------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./schemas/DataPlaneRegistrationMessage.schema.json)                                   |
+| **Required** | - `dataplaneId`: the data plane id                                                                  |
+|              | - `endpoint`: The data plane signaling endpoint.                                                    |
 |              | - `transferTypes`: An array of one or more strings corresponding to supported transfer types.       |
 | **Optional** | - `authorization`: an array of one or more authorization objects .                                  |
 |              | - `labels`: an array of one or more strings corresponding to labels associated with the data plane. |
@@ -680,17 +681,17 @@ Control Plane registration is the process where a [=Control Plane=] is registere
 
 The control plane registration object contains the following properties:
 
-|              |                                                                    |
-| ------------ | ------------------------------------------------------------------ |
-| **Schema**   | [JSON Schema](./resources/TBD)                                     |
-| **Required** | - `endpoint`: The control plane signaling endpoint.                |
-| **Optional** | - `authorization`: an array of one or more authorization objects . |
+|              |                                                                      |
+|--------------|----------------------------------------------------------------------|
+| **Schema**   | [JSON Schema](./schemas/ControlPlaneRegistrationMessage.schema.json) |
+| **Required** | - `controlplaneId`: the control plane id                             |
+| **Optional** | - `authorization`: an array of one or more authorization objects .   |
 
 The following is a non-normative example of a Control Plane registration data object:
 
 ```json
 {
-  "dataplaneId": "bcf2d204-03bc-4354-8e92-b15b68d3c358",
+  "controlplaneId": "bcf2d204-03bc-4354-8e92-b15b68d3c358",
   "endpoint": "https://example.com/signaling",
   "authorization": [
     {

--- a/signaling-control-plane-openapi.yaml
+++ b/signaling-control-plane-openapi.yaml
@@ -171,7 +171,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DataPlaneRegistrationMessage'
+              $ref: 'https://eclipse-dataplane-signaling.github.io/dataplane-signaling/schemas/DataPlaneRegistrationMessage.schema.json'
       responses:
         '200':
           description: Data plane registered successfully
@@ -200,7 +200,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DataPlaneRegistrationMessage'
+              $ref: 'https://eclipse-dataplane-signaling.github.io/dataplane-signaling/schemas/DataPlaneRegistrationMessage.schema.json'
       responses:
         '200':
           description: Data plane registration updated successfully
@@ -233,76 +233,3 @@ paths:
 externalDocs:
   description: Find out more about Dataplane Signaling Protocol
   url: 'https://github.com/eclipse-dataplane-signaling/dataplane-signaling/blob/main/docs/signaling.md'
-
-components:
-  schemas:
-
-    DataPlaneRegistrationMessage:
-      type: object
-      required: [dataplaneId, name, endpoint, transferTypes, authorization]
-      properties:
-        dataplaneId:
-          type: string
-          description: The unique identifier of the data plane
-          example: dataplane-64345
-        endpoint:
-          type: string
-          description: The base URL of the data plane's Signaling API endpoint
-          example: https://dataplane.example.com/api/v1/signaling
-          format: uri
-        transferTypes:
-          type: array
-          description: A list of transfer types supported by the data plane
-          items:
-            $ref: '#/components/schemas/TransferType'
-          example:
-            - "com.test.http-pull"
-            - "com.test.mqtt-push-com.test.mqtt"
-        authorization:
-          type: array
-          description: an array of one or more authorization objects
-          items:
-            properties:
-              type:
-                type: string
-                description: The authorization profile
-                example: "oauth2_client_credentials"
-              tokenEndpoint:
-                type: string
-                description: The token endpoint to be used for obtaining access tokens
-                example: "https://auth.example.com/oauth2/token"
-              clientId:
-                type: string
-                description: The client ID for the authorization profile
-                example: "123456789"
-              clientSecret:
-                type: string
-                description: The client secret for the authorization profile
-                example: "s3cr3t"
-        labels:
-          type: array
-          description: an array of one of more strings corresponding to labels associated with the data plane
-          items:
-            type: string
-          example:
-            - "label1"
-            - "label2"
-
-    TransferType:
-      type: string
-      description: The flow transfer type
-      example: com.test.http-pull
-
-  securitySchemes:
-    petstore_auth:
-      type: oauth2
-      flows:
-        implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
-          scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
-    api_key:
-      type: apiKey
-      name: api_key
-      in: header

--- a/signaling-data-plane-openapi.yaml
+++ b/signaling-data-plane-openapi.yaml
@@ -298,7 +298,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ControlPlaneRegistrationData'
+              $ref: 'https://eclipse-dataplane-signaling.github.io/dataplane-signaling/schemas/ControlPlaneRegistrationMessage.schema.json'
       responses:
         '200':
           description: Control plane registered successfully
@@ -327,7 +327,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ControlPlaneRegistrationData'
+              $ref: 'https://eclipse-dataplane-signaling.github.io/dataplane-signaling/schemas/ControlPlaneRegistrationMessage.schema.json'
       responses:
         '200':
           description: Control plane registration updated successfully
@@ -360,60 +360,3 @@ paths:
 externalDocs:
   description: Find out more about Dataplane Signaling Protocol
   url: 'https://github.com/eclipse-dataplane-signaling/dataplane-signaling/blob/main/docs/signaling.md'
-
-components:
-  schemas:
-
-    ControlPlaneRegistrationData:
-      type: object
-      required: [controlplaneId,name,endpoint,authorization]
-      properties:
-        controlplaneId:
-          type: string
-          description: The unique identifier of the control plane
-          example: controlplane-64345
-        endpoint:
-          type: string
-          description: The base URL of the control plane's Signaling API endpoint
-          example: https://dataplane.example.com/api/v1/signaling
-          format: uri
-        authorization:
-          type: array
-          description: an array of one or more authorization objects
-          items:
-            properties:
-              type:
-                type: string
-                description: The authorization profile
-                example: "oauth2_client_credentials"
-              tokenEndpoint:
-                type: string
-                description: The token endpoint to be used for obtaining access tokens
-                example: "https://auth.example.com/oauth2/token"
-              clientId:
-                type: string
-                description: The client ID for the authorization profile
-                example: "123456789"
-              clientSecret:
-                type: string
-                description: The client secret for the authorization profile
-                example: "s3cr3t"
-
-    TransferType:
-      type: string
-      description: The flow transfer type
-      example: com.test.http-pull
-
-  securitySchemes:
-    petstore_auth:
-      type: oauth2
-      flows:
-        implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
-          scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
-    api_key:
-      type: apiKey
-      name: api_key
-      in: header


### PR DESCRIPTION
### What
converts `ControlPlaneRegistrationMessage` and `DataPlaneRegistrationMessage` to json schema
also extracted the common `AuthorizationEntry` schema

Closes #44 