### PR TITLE
docs: simplify control/data plane registration semantics

### DIFF
--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -557,7 +557,7 @@ request does not exist.
 |-----------------|-------------------------------------------|
 | **HTTP Method** | `POST`                                    |
 | **URL Path**    | `/transfers/:transferId/dataflow/errored` |
-| **Request**     | [`DataFlowStatusMessage`]               |
+| **Request**     | [`DataFlowStatusMessage`]                 |
 | **Response**    | `HTTP 200` OR `HTTP 4xx Client Error`     |
 
 ## Registration
@@ -624,38 +624,24 @@ contain additional properties specific to the profile.
 A [=Control Plane=] implementation MAY support registration through configuration. In this scenario, the way
 configuration is applied is implementation-specific.
 
-#### Endpoint Registration
+#### Registration and update endpoint
 
 A [=Control Plane=] implementation MAY support registration through an endpoint. The endpoint is defined as follows:
 
 |                 |                                       |
 |-----------------|---------------------------------------|
-| **HTTP Method** | `POST`                                |
-| **URL Path**    | `/dataplanes/register`                |
+| **HTTP Method** | `PUT`                                 |
+| **URL Path**    | `/dataplanes`                         |
 | **Request**     | [`DataPlaneRegistrationMessage`]      |
 | **Response**    | `HTTP 200` OR `HTTP 4xx Client Error` |
 
-The `DataPlaneRegistrationMessage` adheres to the [Registration type](#the-data-plane-registration-type) structure. The
+The `DataPlaneRegistrationMessage` adheres to the [Registration type](#the-data-plane-registration-message) structure. The
 endpoint MAY require an authorization mechanism such as OAuth 2.0 or API Key. This is implementation-specific.
 
 Note that the endpoint is relative and may include additional context information such as a sub-path that indicates a
-participant ID the registration applies to.
+participant ID the registration applies to or the API version.
 
-TODO: Define DataPlaneRegistrationRegistrationMessage, including the `dataplaneId` property.
-
-#### Endpoint Update
-
-If the [=Control Plane=] implementation supports endpoint registration, it MUST support endpoint updates. The endpoint
-update is defined as follows:
-
-|                 |                                       |
-|-----------------|---------------------------------------|
-| **HTTP Method** | `PUT`                                 |
-| **URL Path**    | `/dataplanes/:dataplaneId`            |
-| **Request**     | [`DataPlaneRegistrationMessage`]      |
-| **Response**    | `HTTP 200` OR `HTTP 4xx Client Error` |
-
-Update semantics are defined as a `replace` operation.
+Subsequent calls of this endpoint with the same `dataplaneId` will update the stored Data-Plane.
 
 ##### Deletion
 
@@ -711,44 +697,30 @@ is applied is implementation-specific.
 A [=Data Plane=] implementation MAY support registration through an endpoint. The endpoint is defined as follows:
 
 |                 |                                       |
-| --------------- | ------------------------------------- |
-| **HTTP Method** | `POST`                                |
-| **URL Path**    | `/controlplanes/registration`         |
+|-----------------|---------------------------------------|
+| **HTTP Method** | `PUT`                                 |
+| **URL Path**    | `/controlplanes`                      |
 | **Request**     | [`ControlPlaneRegistrationMessage`]   |
 | **Response**    | `HTTP 200` OR `HTTP 4xx Client Error` |
 
-The `ControlPlaneRegistrationMessage` adheres to the [Registration type](#the-registration-type) structure. The endpoint
-MAY require an authorization mechanism such as OAuth 2.0 or API Key. This is implementation-specific.
+The `ControlPlaneRegistrationMessage` adheres to the [Registration type](#the-control-plane-registration-type) structure.
+The endpoint MAY require an authorization mechanism such as OAuth 2.0 or API Key. This is implementation-specific.
 
 Note that the endpoint is relative and may include additional context information such as a sub-path that indicates a
 participant ID the registration applies to.
 
-TODO: Define DataPlaneRegistrationRegistrationMessage, including the `dataplaneId` property.
-
-#### Endpoint Update
-
-If the [=Data Plane=] implementation supports endpoint registration, it MUST support endpoint updates. The endpoint
-update is defined as follows:
-
-|                 |                                               |
-| --------------- | --------------------------------------------- |
-| **HTTP Method** | `PUT`                                         |
-| **URL Path**    | `/controlplanes/:controlplaneId/registration` |
-| **Request**     | [`ControlPlaneRegistrationMessage`]           |
-| **Response**    | `HTTP 200` OR `HTTP 4xx Client Error`         |
-
-Update semantics are defined as a `replace` operation.
+Subsequent calls of this endpoint with the same `controlplaneId` will update the stored Control-Plane.
 
 ##### Deletion
 
 If the [=Data Plane=] implementation supports endpoint registration, it MUST support endpoint deletion defined as
 follows:
 
-|                 |                                               |
-| --------------- | --------------------------------------------- |
-| **HTTP Method** | `DELETE`                                      |
-| **URL Path**    | `/controlplanes/:controlplaneId/registration` |
-| **Response**    | `HTTP 204` OR `HTTP 4xx Client Error`         |
+|                 |                                       |
+|-----------------|---------------------------------------|
+| **HTTP Method** | `DELETE`                              |
+| **URL Path**    | `/controlplanes/:controlplaneId`      |
+| **Response**    | `HTTP 204` OR `HTTP 4xx Client Error` |
 
 ### Authorization Profiles
 

--- a/signaling-control-plane-openapi.yaml
+++ b/signaling-control-plane-openapi.yaml
@@ -157,45 +157,17 @@ paths:
         '404':
           description: Not Found - transfer process with specified ID does not exist
 
-  /dataplanes/register:
-    post:
-      tags:
-        - Data Plane Registration
-      summary: Register a data plane on the control plane.
-      description: |
-        The register endpoint is hosted on the control plane, and may be used to register a data plane on the control plane.
-      operationId: registerDataplane
-      requestBody:
-        description: Data plane registration data
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: 'https://w3id.org/dspace-sig/v1.0/DataPlaneRegistrationMessage.schema.json'
-      responses:
-        '200':
-          description: Data plane registered successfully
-        '400':
-          description: Bad Request - invalid input, invalid object state or missing required parameters
-
-  /dataplanes/{dataplaneId}:
+  /dataplanes:
     put:
       tags:
         - Data Plane Registration
-      summary: Update a data plane registration with replace semantics
+      summary: Create or Update a data plane registration
       description: |
-        The registration endpoint is hosted on the control plane, and may be used to update an existing data plane registration, fully replacing the existing one.
-      operationId: updateDataplaneRegistration
-      parameters:
-        - name: dataplaneId
-          in: path
-          required: true
-          description: The unique identifier of the data plane to update
-          schema:
-            type: string
-            example: dataplane-64345
+        The registration endpoint is hosted on the control plane, and may be used to create a new data plane or to
+        update an existing data plane registration, fully replacing the existing one.
+      operationId: upsertDataplaneRegistration
       requestBody:
-        description: Updated data plane registration data
+        description: Data plane registration data
         required: true
         content:
           application/json:
@@ -206,8 +178,6 @@ paths:
           description: Data plane registration updated successfully
         '400':
           description: Bad Request - invalid input, invalid object state or missing required parameters
-        '404':
-          description: Not Found - data plane with specified ID does not exist
 
     delete:
       tags:

--- a/signaling-data-plane-openapi.yaml
+++ b/signaling-data-plane-openapi.yaml
@@ -284,45 +284,17 @@ paths:
         '404':
           description: Not Found - data flow with specified ID does not exist
 
-  /controlplanes/register:
-    post:
-      tags:
-        - Control Plane Registration
-      summary: Register a control plane with a data plane.
-      description: |
-        The register endpoint is hosted on the data plane, and may be used to register a control plane with the data plane.
-      operationId: registerControlPlane
-      requestBody:
-        description: Control plane registration data
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: 'https://w3id.org/dspace-sig/v1.0/ControlPlaneRegistrationMessage.schema.json'
-      responses:
-        '200':
-          description: Control plane registered successfully
-        '400':
-          description: Bad Request - invalid input, invalid object state or missing required parameters
-
-  /controlplanes/{controlplaneId}/registration:
+  /controlplanes:
     put:
       tags:
         - Control Plane Registration
-      summary: Update a control plane registration with replace semantics
+      summary: Create or Update a control plane registration
       description: |
-        The registration endpoint is hosted on the data plane, and may be used to update an existing control plane registration, fully replacing the existing one.
-      operationId: updateControlplaneRegistration
-      parameters:
-        - name: controlplaneId
-          in: path
-          required: true
-          description: The unique identifier of the control plane to update
-          schema:
-            type: string
-            example: control-64345
+        The registration endpoint is hosted on the data plane, and may be used to create a new control plane or to
+        update an existing control plane registration, fully replacing the existing one.
+      operationId: upsertControlplaneRegistration
       requestBody:
-        description: Updated control plane registration data
+        description: Control plane registration data
         required: true
         content:
           application/json:
@@ -333,8 +305,6 @@ paths:
           description: Control plane registration updated successfully
         '400':
           description: Bad Request - invalid input, invalid object state or missing required parameters
-        '404':
-          description: Not Found - data plane with specified ID does not exist
 
     delete:
       tags:


### PR DESCRIPTION
### What

Define single `PUT` registration endpoint for control and data plane, following the [RFC 9110 specs](https://www.rfc-editor.org/rfc/rfc9110.html#name-put):

> The PUT method requests that the state of the [target resource](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) be created or replaced with the state defined by the representation enclosed in the request message content

Closes #58 