### PR TITLE
docs: terminated event propagation

### DIFF
--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -653,14 +653,22 @@ The `completed` request signals to the [=Control Plane=] that the [=Data Flow=] 
 
 #### Errored
 
-The `errored` request signals to the [=Control Plane=] that the [=Data Flow=] is in the TERMINATED state due to a
-non-recoverable error at the [=Wire Protocol=] layer.
+The `errored` request notifies the [=Control Plane=] that a non-recoverable error has occurred at the [=Wire Protocol=]
+layer. This request does not cause a state transition. The [=Control Plane=] MUST NOT propagate this event to the
+counterparty. Instead, the [=Control Plane=] must independently decide how to recover: through operator intervention,
+restarting the transfer process, or creating a new transfer.
 
 Note that only terminal, non-recoverable errors should be reported to the [=Control Plane=]. Transient errors should be
 handled by the [=Data Plane=].
 
-NOTE see [Terminated Event propagation](https://github.com/eclipse-dataplane-signaling/dataplane-signaling/issues/1) for why a `terminated`
-request does not exist.
+NOTE: A `terminated` request does not exist because direct termination signaling from the [=Data Plane=] to the
+[=Control Plane=] would create conflicting dual-termination scenarios. For example, if a provider data plane terminates
+due to a policy violation and closes the socket, the consumer data plane may independently detect this as a wire
+protocol error and send an `errored` message. Since these terminations cannot be correlated, propagating both as
+TERMINATED events would violate the DSP constraint that a transfer process cannot transition from TERMINATED to
+TERMINATED. [=Wire Protocol=] specifications MUST define what constitutes abnormal termination; for example, a socket
+close without a prior terminated message may be interpreted as an error, while a terminated message followed by a
+socket close is not.
 
 |                 |                                           |
 |-----------------|-------------------------------------------|

--- a/signaling-control-plane-openapi.yaml
+++ b/signaling-control-plane-openapi.yaml
@@ -127,10 +127,13 @@ paths:
     post:
       tags:
         - Control plane endpoints
-      summary: Signals the TERMINATED state
+      summary: Signals a non-recoverable error
       description: |
-        The prepared request signals to the control plane that the data plane is in the TERMINATED state which indicates abnormal termination.
-      operationId: signalTerminated
+        The errored request notifies the control plane that a non-recoverable error has occurred at the wire protocol
+        layer. This request does not cause a state transition. The control plane must not propagate this event to the
+        counterparty and must independently decide on recovery: operator intervention, restarting the transfer process,
+        or creating a new transfer.
+      operationId: signalErrored
       parameters:
         - name: transferId
           in: path
@@ -140,7 +143,7 @@ paths:
             type: string
             example: 93a78371-7891-495e-afb5-9b11ac6b1e94
       requestBody:
-        description: DataFlow terminated notification
+        description: DataFlow errored notification
         required: true
         content:
           application/json:
@@ -148,7 +151,8 @@ paths:
               $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
             example:
               dataplaneId: dataplane-64345
-              state: TERMINATED
+              state: STARTED
+              error: Unrecoverable wire protocol error
       responses:
         '200':
           description: Notification received successfully


### PR DESCRIPTION
### What
Detail the `errored` signal, that shouldn't cause a TP state change in the CP but it's just a notification that the control plane could take into consideration to act properly but it could also be ignored.

Closes #1 