### PR TITLE
docs: add claims to prepare and start signals

### DIFF
--- a/docs/schemas/DataFlowBaseMessage.schema.json
+++ b/docs/schemas/DataFlowBaseMessage.schema.json
@@ -40,6 +40,10 @@
             "type": "string",
             "description": "the flow transfer type"
         },
+        "claims": {
+            "type": "object",
+            "description": "DSP claims of the counterparty as verified by the control plane"
+        },
         "metadata": {
             "type": "object"
         },
@@ -58,6 +62,7 @@
         "processId",
         "agreementId",
         "datasetId",
-        "transferType"
+        "transferType",
+        "claims"
     ]
 }

--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -334,6 +334,7 @@ PREPARED, the [=Data Plane=] MUST return HTTP 200 OK and a `DataFlowStatusMessag
 |                | - `datasetId`: The ID of the dataset in the DCAT Catalog which is to be transferred.                                   |
 |                | - `callbackAddress`: A URL where the control plane receives callbacks.                                                 |
 |                | - `transferType`: The type of data transfer. See [data transfer types](#data-transfer-types).                          |
+|                | - `claims`: An object containing the DSP claims of the counterparty as verified by the control plane.                  |
 | **Optional**:  | - `labels`: an array of strings that represent different flavours of data flow                                         |
 |                | - `metadata`: An object containing information that could be used by the data plane during preparation.                |
 
@@ -350,6 +351,10 @@ The following is a non-normative example of a `DataFlowPrepareMessage`:
   "datasetId": "asset-id",
   "callbackAddress": "https://example.com/provider/callback",
   "transferType": "com.test.s3-PUSH",
+  "claims": {
+    "membership": "active",
+    "sub": "subject"
+  },
   "labels": ["gold", "blue"],
   "metadata": {
     "bucketName": "destinationBucket",
@@ -411,6 +416,7 @@ Accepted with the `Location` header set to the [data flow status relative URL](#
 |              | - `datasetId`: The ID of the dataset in the DCAT Catalog which is to be transferred.                                                                                                        |
 |              | - `callbackAddress`: A URL where the control plane receives callbacks.                                                                                                                      |
 |              | - `transferType`: The type of data transfer. See [data transfer types](#data-transfer-types).                                                                                               |
+|              | - `claims`: An object containing the DSP claims of the counterparty as verified by the control plane.                                                                                       |
 | **Optional** | - `dataAddress`: An object containing information about where the provider should push data (provider push). Must be omitted on consumer pull transfers. See [data address](#data-address). |
 |              | - `labels`: an array of strings that represent different flavours of data flow                                                                                                              |
 |              | - `metadata`: An object containing information that could be used by the data plane during startup.                                                                                         |
@@ -432,6 +438,10 @@ provider and must be accessed by the provider data plane using an API Key:
   "datasetId": "asset-id",
   "callbackAddress": "https://example.com/provider/callback",
   "transferType": "com.test.http-PULL",
+  "claims": {
+    "membership": "active",
+    "sub": "subject"
+  },
   "dataAddress": {
     "endpointType": "https://w3id.org/idsa/v4.1/HTTP",
     "endpoint": "http://dataplane.provider.com/api/public",


### PR DESCRIPTION
Adds `claims` to the `prepare` and `start` messages

Closes #79 