### PR TITLE
docs: remove dataplaneId attribute from DataFlowStatusMessage

### DIFF
--- a/docs/schemas/DataFlowStatusMessage.schema.json
+++ b/docs/schemas/DataFlowStatusMessage.schema.json
@@ -4,9 +4,6 @@
     "title": "DataFlowStatusMessage",
     "type": "object",
     "properties": {
-        "dataplaneId": {
-            "type": "string"
-        },
         "dataFlowId": {
             "type": "string"
         },
@@ -31,7 +28,6 @@
         }
     },
     "required": [
-        "dataplaneId",
         "dataFlowId",
         "state"
     ]

--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -368,9 +368,8 @@ The following is a non-normative example of a `DataFlowPrepareMessage`:
 
 |              |                                                                                                                                     |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| **Schema**   | [JSON Schema](./schemas/DataFlowStatusMessage.schema.json)                                                                        |
-| **Required** | - `dataplaneId`: The unique identifier of the data plane.                                                                           |
-|              | - `dataFlowId`: The unique identifier of the data flow.                                                                             |
+| **Schema**   | [JSON Schema](./schemas/DataFlowStatusMessage.schema.json)                                                                          |
+| **Required** | - `dataFlowId`: The unique identifier of the data flow.                                                                             |
 |              | - `state`: The current state of the data flow.                                                                                      |
 | **Optional** | - `dataAddress`: An object containing information about where the data can be obtained/provided. See [data address](#data-address). |
 |              | - `error`: A description of any error that occurred during processing.                                                              |
@@ -379,7 +378,6 @@ The following is a non-normative example of a `DataFlowStatusMessage`:
 
 ```json
 {
-  "dataplaneId": "ha-dataplane-123",
   "dataFlowId": "dataFlow-123",
   "dataAddress": {},
   "state": "PREPARED",

--- a/signaling-control-plane-openapi.yaml
+++ b/signaling-control-plane-openapi.yaml
@@ -45,7 +45,6 @@ paths:
             schema:
               $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
             example:
-              dataplaneId: dataplane-64345
               state: PREPARED
       responses:
         '200':
@@ -79,7 +78,6 @@ paths:
             schema:
               $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
             example:
-              dataplaneId: dataplane-64345
               state: STARTED
       responses:
         '200':
@@ -113,7 +111,6 @@ paths:
             schema:
               $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
             example:
-              dataplaneId: dataplane-64345
               state: COMPLETED
       responses:
         '200':
@@ -150,7 +147,6 @@ paths:
             schema:
               $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
             example:
-              dataplaneId: dataplane-64345
               state: STARTED
               error: Unrecoverable wire protocol error
       responses:

--- a/signaling-data-plane-openapi.yaml
+++ b/signaling-data-plane-openapi.yaml
@@ -40,7 +40,6 @@ paths:
               schema:
                 $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
               example:
-                dataplaneId: dataplane-64345
                 state: PREPARED
         '202':
           description: Request received, DataFlow preparation in progress
@@ -56,7 +55,6 @@ paths:
               schema:
                 $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
               example:
-                dataplaneId: dataplane-64345
                 state: PREPARING
         '400':
           description: Bad Request - invalid input, invalid object state or missing required parameters, supplying the
@@ -133,7 +131,6 @@ paths:
               schema:
                 $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
               example:
-                dataplaneId: dataplane-64345
                 state: STARTED
                 dataAddress:
                   endpointType: https://23id.org.idsa/v4.1/HTTP
@@ -158,7 +155,6 @@ paths:
                 $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
               example:
                 example:
-                  dataplaneId: dataplane-64345
                   state: STARTING
         '400':
           description: Bad Request - invalid input, invalid object state or missing required parameters, supplying a
@@ -225,7 +221,6 @@ paths:
               schema:
                 $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusMessage.schema.json'
               example:
-                dataplaneId: dataplane-64345
                 state: STARTED
         '400':
           description: Bad Request - invalid input, invalid object state or missing required parameters
@@ -286,7 +281,6 @@ paths:
               schema:
                 $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowStatusResponseMessage.schema.json'
               example:
-                dataplaneId: dataplane-64345
                 state: PREPARING
         '400':
           description: Bad Request - invalid input, invalid object state or missing required parameters


### PR DESCRIPTION
Removes `dataplaneId` from the `DataFlowStatusMessage`

closes #86 