### PR TITLE
feat: add messageId on all the messages

### DIFF
--- a/docs/schemas/DataFlowResumeMessage.schema.json
+++ b/docs/schemas/DataFlowResumeMessage.schema.json
@@ -7,16 +7,11 @@
             "type": "string",
             "description": "Unique identifier for the message"
         },
-        "processId": {
-            "type": "string",
-            "description": "Associated process identifier. This should be the transfer process ID."
-        },
         "dataAddress": {
             "$ref": "https://w3id.org/dspace/2025/1/transfer/data-address-schema.json"
         }
     },
     "required": [
-        "messageId",
-        "processId"
+        "messageId"
     ]
 }

--- a/docs/schemas/DataFlowSuspendMessage.schema.json
+++ b/docs/schemas/DataFlowSuspendMessage.schema.json
@@ -4,8 +4,15 @@
     "title": "DataFlowSuspendMessage",
     "type": "object",
     "properties": {
+        "messageId": {
+            "type": "string",
+            "description": "Unique identifier for the message"
+        },
         "reason": {
             "type": "string"
         }
-    }
+    },
+    "required": [
+        "messageId"
+    ]
 }

--- a/docs/schemas/DataFlowTerminateMessage.schema.json
+++ b/docs/schemas/DataFlowTerminateMessage.schema.json
@@ -4,8 +4,15 @@
     "title": "DataFlowTerminateMessage",
     "type": "object",
     "properties": {
+        "messageId": {
+            "type": "string",
+            "description": "Unique identifier for the message"
+        },
         "reason": {
             "type": "string"
         }
-    }
+    },
+    "required": [
+        "messageId"
+    ]
 }

--- a/docs/signaling.md
+++ b/docs/signaling.md
@@ -528,12 +528,14 @@ The `suspend` request signals to the [=Data Plane=] to suspend a data transfer.
 |              |                                                                       |
 | ------------ | --------------------------------------------------------------------- |
 | **Schema**   | [JSON Schema](./schemas/DataFlowSuspendMessage.schema.json)           |
+| **Required** | - `messageId`: A unique identifier for the message.                   |
 | **Optional** | - `reason`: A description of the reason for suspending the data flow. |
 
 The following is a non-normative example of a `DataFlowSuspendMessage`:
 
 ```json
 {
+  "messageId": "b1d5f9e2-3c4b-4f7a-9c3e-2f1e5d6c7b8a",
   "reason": "Suspending data flow due to scheduled maintenance."
 }
 ```
@@ -555,7 +557,6 @@ The `resume` request signals to the [=Data Plane=] to resume a data transfer.
 |--------------|--------------------------------------------------------------------------------------------------------------------------|
 | **Schema**   | [JSON Schema](./schemas/DataFlowResumeMessage.schema.json)                                                               |
 | **Required** | - `messageId`: A unique identifier for the message.                                                                      |
-|              | - `processId`: The transfer process ID as assigned by the control plane for correlation.                                 |
 | **Optional** | - `dataAddress`: A [DataAddress](#data-address) that contains information about where the data can be obtained/provided. |
 
 The following is a non-normative example of a `DataFlowResumeMessage`:
@@ -563,7 +564,6 @@ The following is a non-normative example of a `DataFlowResumeMessage`:
 ```json
 {
   "messageId": "b1d5f9e2-3c4b-4f7a-9c3e-2f1e5d6c7b8a",
-  "processId": "test-transfer-process-id",
   "dataAddress": {}
 }
 ```
@@ -584,12 +584,14 @@ The `terminate` request signals to the [=Data Plane=] to terminate a data transf
 |              |                                                                        |
 | ------------ | ---------------------------------------------------------------------- |
 | **Schema**   | [JSON Schema](./schemas/DataFlowTerminateMessage.schema.json)          |
+| **Required** | - `messageId`: A unique identifier for the message.                    |
 | **Optional** | - `reason`: A description of the reason for terminating the data flow. |
 
 The following is a non-normative example of a `DataFlowTerminateMessage`:
 
 ```json
 {
+  "messageId": "b1d5f9e2-3c4b-4f7a-9c3e-2f1e5d6c7b8a",
   "reason": "Terminating data flow due to an unrecoverable error."
 }
 ```

--- a/signaling-data-plane-openapi.yaml
+++ b/signaling-data-plane-openapi.yaml
@@ -171,11 +171,14 @@ paths:
         The suspend request signals to the data plane to suspend an ongoing data transfer.
       operationId: suspendDataFlowById
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
               $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowSuspendMessage.schema.json'
+            example:
+              messageId: b1d5f9e2-3c4b-4f7a-9c3e-2f1e5d6c7b8a
+              reason: Suspending data flow due to scheduled maintenance.
       parameters:
         - name: id
           in: path
@@ -201,10 +204,13 @@ paths:
         The suspend request signals to the data plane to resume a suspended data transfer.
       operationId: resumeDataFlowById
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowResumeMessage.schema.json'
+            example:
+              messageId: b1d5f9e2-3c4b-4f7a-9c3e-2f1e5d6c7b8a
       parameters:
         - name: id
           in: path
@@ -236,11 +242,14 @@ paths:
         The terminate request signals to the data plane to terminate an ongoing data transfer.
       operationId: terminateDataFlowById
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
               $ref: 'https://w3id.org/dspace-sig/v1.0/DataFlowTerminateMessage.schema.json'
+            example:
+              messageId: b1d5f9e2-3c4b-4f7a-9c3e-2f1e5d6c7b8a
+              reason: Terminating data flow due to an unrecoverable error.
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
### What
Adds `messageId` where missing on the signaling messages to data-plane, to permit message deduplication

### Note
- removed `processId` from the terminate message as that information is already obtainable from the path

Closes #88 