### PR TITLE
fix: redirect for respec webpage

### DIFF
--- a/.github/scripts/index.html
+++ b/.github/scripts/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="refresh"
-          content="0;url=https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1"/>
-    <link rel="canonical" href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1"/>
+          content="0;url=https://eclipse-dataplane-signaling.github.io/dataplane-signaling/HEAD"/>
+    <link rel="canonical" href="https://eclipse-dataplane-signaling.github.io/dataplane-signaling/HEAD"/>
 </head>
 <body>
 <h4>
-    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1">here</a>
+    This redirects to the latest Release Candidate <a href="https://eclipse-dataplane-signaling.github.io/dataplane-signaling/HEAD">here</a>
 </h4>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 ![](docsogo/dataplane.signaling.logo.svg)
 
 A specification for interoperable communication between Dataspace Protocol control planes and data planes.
+
+Public specification: https://eclipse-dataplane-signaling.github.io/dataplane-signaling

--- a/WEBSITE.md
+++ b/WEBSITE.md
@@ -67,7 +67,7 @@ and then (independently of major/minor) a second commit
 - Rerun the actions.
 
 You should now see an additional endpoint at
-`https://eclipse-dataplane-signaling/dataplane-signaling/my-version-tag/`.
+`https://eclipse-dataplane-signaling.github.io/dataplane-signaling/my-version-tag/`.
 
 #### Github Release
 

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            edDraftURI: "https://eclipse-dataplane-signaling/dataplane-signaling/HEAD",
-            latestVersion: "https://eclipse-dataplane-signaling/dataplane-signaling/1.0-RC1",
+            edDraftURI: "https://eclipse-dataplane-signaling.github.io/dataplane-signaling/HEAD",
+            latestVersion: "https://eclipse-dataplane-signaling.github.io/dataplane-signaling/1.0-RC1",
             specStatus: "unofficial",
             editors: [{
                 name: "Jim Marino",


### PR DESCRIPTION
Fixes redirects.

NOTE: redirects to `HEAD`, because in the `v1.0-RC1` tag, the index.html file wasn't existing yet.

Closes #94 