### PR TITLE
docs: use mermaid plugin in respec render

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This file provides an overview of responsibilities in this repository.
+
+# Please note that this file does not represent all contributions to the code. What persons and organizations
+# actually contributed to each file can be seen on GitHub and is documented in the license headers.
+
+# Linked persons with write permissions are automatically added as reviewers when a pull request is opened.
+
+# Each line is a file pattern followed by one or more contact persons. The last matching pattern has the most precedence.
+# For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
+
+* @eclipse-dataplane-signaling/technology-dataplane-signaling-committers

--- a/index.html
+++ b/index.html
@@ -3,11 +3,13 @@
 <head>
     <meta charset='utf-8'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
+    <script src="https://cdn.jsdelivr.net/gh/w3c/respec-mermaid@1.3.0/dist/main.js" class="remove"></script>
     <script class='remove'>
         var respecConfig = {
             edDraftURI: "https://eclipse-dataplane-signaling.github.io/dataplane-signaling/HEAD",
             latestVersion: "https://eclipse-dataplane-signaling.github.io/dataplane-signaling/1.0-RC1",
             specStatus: "unofficial",
+            preProcess: [window.respecMermaid.createFigures],
             editors: [{
                 name: "Jim Marino",
                 url: "https://github.com/jimmarino",
@@ -93,7 +95,7 @@
 <p class="copyright">
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License, Version 2.0</a>.
     <br/>
-    Copyright © 2025 The Eclipse Foundation AISBL
+    Copyright © 2026 The Eclipse Foundation AISBL
 </p>
 <h1 id="title">Data Plane Signaling 1.0-RC1</h1>
 <section id='abstract'>


### PR DESCRIPTION
### What
Adds [`respec-mermaid`](https://github.com/w3c/respec-mermaid) plugin to the respec render

### Note
- added also the codeowners file, so for the PRs the committer members will be added as reviewers by default.

Closes #96 