### PR TITLE
docs: document OpenApi spec links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,9 @@
 
 A specification for interoperable communication between Dataspace Protocol control planes and data planes.
 
-Public specification: https://eclipse-dataplane-signaling.github.io/dataplane-signaling
+Public specification: 
+- https://eclipse-dataplane-signaling.github.io/dataplane-signaling
+
+OpenApi spec (replace `HEAD` with the version for a specific spec version):
+- control-plane: https://eclipse-dataplane-signaling.github.io/dataplane-signaling/HEAD/api/control-plane/
+- data-plane: https://eclipse-dataplane-signaling.github.io/dataplane-signaling/HEAD/api/data-plane/


### PR DESCRIPTION
Adds link for openapi spec ui that now are published on GH pages.
(the actual work has been done directly on master to make it quicker)


Closes #42